### PR TITLE
Notification in private browsing 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/activity/PrivateModeNotification.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/activity/PrivateModeNotification.kt
@@ -1,0 +1,255 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 4; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.activity
+
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.support.test.espresso.IdlingRegistry
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.focus.R
+import org.mozilla.focus.autobot.notification
+import org.mozilla.focus.autobot.private
+import org.mozilla.focus.autobot.session
+import org.mozilla.focus.helper.BeforeTestTask
+import org.mozilla.focus.helper.SessionLoadedIdlingResource
+import org.mozilla.focus.screengrab.BaseScreenshot
+import org.mozilla.rocket.privately.PrivateModeActivity
+
+@RunWith(AndroidJUnit4::class)
+class PrivateModeNotification : BaseScreenshot() {
+
+    private var loadingIdlingResource: SessionLoadedIdlingResource? = null
+    private var notificationManager: NotificationManager? = null
+
+    @JvmField
+    @Rule
+    var activityTestRule = ActivityTestRule(PrivateModeActivity::class.java, true, false)
+
+    @Before
+    fun setUp() {
+        BeforeTestTask.Builder().build().execute()
+
+        // launch app
+        activityTestRule.launchActivity(Intent())
+        notificationManager = activityTestRule.activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notification {
+            dismissNotification(activityTestRule.activity)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        if (loadingIdlingResource != null) {
+            IdlingRegistry.getInstance().unregister(loadingIdlingResource!!)
+        }
+    }
+
+    /**
+     * Test case no: TC0114
+     * Test case name: Tap erase private browsing notification when private browsing
+     * Steps:
+     * 1. Visit site in private mode
+     * 2. Open notification
+     * 3. Tap erase private browsing
+     * 4. Open notification
+     * 5. Check no erase private browsing notification displayed
+     */
+    @Test
+    fun tapErasePrivateBrowsingNotif_whenPrivateBrowsing() {
+
+        private {
+            loadPageFromPrivateSearchField(activityTestRule.activity, PrivateModeNotification.TARGET_URL_SITE)
+        }
+
+        notification {
+            openNotification()
+            clickNotificationWithText(activityTestRule.activity, R.string.private_browsing_erase_message)
+            openNotification()
+            checkNotificationNotDisplayed(activityTestRule.activity, R.string.private_browsing_erase_message)
+        }
+    }
+
+    /**
+     * Test case no: TC0117
+     * Test case name: Tap erase private browsing notification when normal browsing
+     * Steps:
+     * 1. Visit site in private mode
+     * 2. Tap private mode icon so back to normal browsing
+     * 3. Open notification
+     * 4. Tap erase private browsing
+     * 5. Open notification
+     * 6. Check no erase private browsing notification displayed
+     */
+    @Test
+    fun tapErasePrivateBrowsingNotif_whenNormalBrowsing() {
+
+        private {
+            loadPageFromPrivateSearchField(activityTestRule.activity, PrivateModeNotification.TARGET_URL_SITE)
+        }
+
+        notification {
+            openNotification()
+            clickNotificationWithText(activityTestRule.activity, R.string.private_browsing_erase_message)
+            openNotification()
+            checkNotificationNotDisplayed(activityTestRule.activity, R.string.private_browsing_erase_message)
+        }
+    }
+
+    /**
+     * Test case no: TC0112
+     * Test case name:  tap open action notification when private browsing
+     * Steps:
+     * 1. Visit site in private mode
+     * 2. Tap private mode icon so back to normal browsing
+     * 2. Open notification
+     * 3. Tap open
+     * 4. Check private site url matches target
+     */
+    @Test
+    fun tapOpenActionNotif_whenPrivateBrowsing() {
+
+        private {
+            loadPageFromPrivateSearchField(activityTestRule.activity, PrivateModeNotification.TARGET_URL_SITE)
+            tapBackToBrowserInPrivateMenu()
+        }
+
+        notification {
+            openNotification()
+            clickNotificationWithText(activityTestRule.activity, R.string.private_browsing_open_action)
+        }
+
+        private {
+            checkUrlInPrivateMode(PrivateModeNotification.TARGET_URL_SITE)
+        }
+    }
+
+    /**
+     * Test case no: TC0115
+     * Test case name: tap open action notification when normal browsing
+     * Steps:
+     * 1. Visit site in private mode
+     * 2. Tap private mode icon so back to normal browsing
+     * 3. Open notification
+     * 4. Tap open
+     * 5. Check private site url matches target
+     */
+    @Test
+    fun tapOpenActionNotif_whenNormalBrowsing() {
+
+        private {
+            loadPageFromPrivateSearchField(activityTestRule.activity, PrivateModeNotification.TARGET_URL_SITE)
+            tapBackToBrowserInPrivateMenu()
+        }
+
+        notification {
+            openNotification()
+            clickNotificationWithText(activityTestRule.activity, R.string.private_browsing_open_action)
+        }
+
+        private {
+            checkUrlInPrivateMode(PrivateModeNotification.TARGET_URL_SITE)
+        }
+    }
+
+    /**
+     * Test case no: TC0118
+     * Test case name: Tap open action notification after switch to home
+     * Steps:
+     * 1. Visit site in private mode
+     * 2. Tap private mode icon so back to normal browsing
+     * 3. Tap home
+     * 4. Open notification
+     * 5. Tap open
+     * 6. Check private site url matches target
+     */
+    @Test
+    fun tapOpenActionNotif_afterSwitchToHome() {
+
+        private {
+            loadPageFromPrivateSearchField(activityTestRule.activity, PrivateModeNotification.TARGET_URL_SITE)
+            tapBackToBrowserInPrivateMenu()
+        }
+
+        session {
+            goHome(activityTestRule.activity)
+        }
+
+        notification {
+            openNotification()
+            clickNotificationWithText(activityTestRule.activity, R.string.private_browsing_open_action)
+        }
+
+        private {
+            checkUrlInPrivateMode(PrivateModeNotification.TARGET_URL_SITE)
+        }
+    }
+
+    /**
+     * Test case no: TC0120
+     * Test case name: Tap erase private browsing notification after switch to home
+     * Steps:
+     * 1. Visit site in private mode
+     * 2. Tap private mode icon so back to normal browsing
+     * 4. Tap home
+     * 5. Open notification
+     * 6. Tap erase private browsing
+     * 7. Open notification
+     * 8. Check no erase private browsing notification displayed
+     */
+    @Test
+    fun tapErasePrivateBrowsingNotif_afterSwitchToHome() {
+
+        private {
+            loadPageFromPrivateSearchField(activityTestRule.activity, PrivateModeNotification.TARGET_URL_SITE)
+            tapBackToBrowserInPrivateMenu()
+        }
+
+        session {
+            goHome(activityTestRule.activity)
+        }
+        notification {
+            openNotification()
+            clickNotificationWithText(activityTestRule.activity, R.string.private_browsing_erase_message)
+            openNotification()
+            checkNotificationNotDisplayed(activityTestRule.activity, R.string.private_browsing_erase_message)
+        }
+    }
+
+    /**
+     * Test case no: TC0122
+     * Test case name: Show erase private browsing toast when back to private home page
+     * Steps:
+     * 1. Visit site in private mode
+     * 2. Tap back
+     * 3. Show private browsing notification toast
+     */
+    @Test
+    fun showPrivateBrowsingErasedToast_afterbacktoPrivateHomePage() {
+
+        private {
+            loadPageFromPrivateSearchField(activityTestRule.activity, PrivateModeNotification.TARGET_URL_SITE)
+        }
+
+        session {
+            pressBack()
+        }
+
+        private {
+            showToastMessageInPrivateMode(activityTestRule.activity, R.string.private_browsing_erase_done)
+        }
+    }
+
+    companion object {
+        private val TARGET_URL_SITE = "file:///android_asset/gpl.html"
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/autobot/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/autobot/NotificationRobot.kt
@@ -1,0 +1,44 @@
+package org.mozilla.focus.autobot
+
+import android.content.Intent
+import android.support.test.InstrumentationRegistry
+import android.support.test.uiautomator.UiDevice
+import android.support.test.uiautomator.UiObject
+import android.support.test.uiautomator.UiObjectNotFoundException
+import android.support.test.uiautomator.UiSelector
+import org.junit.Assert
+import org.mozilla.rocket.privately.PrivateModeActivity
+
+inline fun notification(func: NotificationRobot.() -> Unit) = NotificationRobot().apply(func)
+class NotificationRobot {
+
+    private var uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+    fun checkNotificationNotDisplayed(activity: PrivateModeActivity, msg: Int) {
+        val notificationTextExist = uiDevice.findObject(UiSelector().text(activity.resources.getString(msg))).exists()
+        Assert.assertFalse(notificationTextExist)
+    }
+
+    fun checkNotificationDisplayed(activity: PrivateModeActivity, msg: Int): UiObject? {
+        var notificationObject = uiDevice.findObject(UiSelector().text(activity.resources.getString(msg)))
+        return notificationObject
+    }
+
+    fun openNotification() {
+        uiDevice.openNotification()
+    }
+
+    fun clickNotificationWithText(activity: PrivateModeActivity, msg: Int) {
+        var notificationObject = checkNotificationDisplayed(activity, msg)
+
+        try {
+            notificationObject?.click()
+        } catch (e: UiObjectNotFoundException) {
+            e.printStackTrace()
+        }
+    }
+    fun dismissNotification(activity: PrivateModeActivity) {
+        val closeIntent = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
+        activity.sendBroadcast(closeIntent)
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/autobot/PrivateRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/autobot/PrivateRobot.kt
@@ -1,0 +1,57 @@
+package org.mozilla.focus.autobot
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.action.ViewActions.pressImeActionButton
+import android.support.test.espresso.action.ViewActions.replaceText
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.support.test.uiautomator.UiDevice
+import android.support.test.uiautomator.UiSelector
+import android.view.View
+import org.hamcrest.Matchers
+import org.mozilla.focus.R
+import org.mozilla.focus.helper.SessionLoadedIdlingResource
+import org.mozilla.focus.utils.AndroidTestUtils
+import org.mozilla.rocket.privately.PrivateModeActivity
+
+inline fun private(func: PrivateRobot.() -> Unit) = PrivateRobot().apply(func)
+class PrivateRobot {
+
+    private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
+    private var uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+    fun loadPageFromPrivateSearchField(activity: PrivateModeActivity, url: String) {
+        // Click private search field
+        onView(Matchers.allOf(withId(R.id.pm_home_fake_input))).perform(click())
+        // create the idlingResource before the new session is created.
+        loadPrivatePage(activity, url)
+    }
+
+    private fun loadPrivatePage(activity: PrivateModeActivity, url: String) {
+        // TODO find a way to remove the activity reference
+        sessionLoadedIdlingResource = SessionLoadedIdlingResource(activity)
+
+        // Enter test site url
+        onView(Matchers.allOf<View>(withId(R.id.url_edit), isDisplayed())).perform(replaceText(url), pressImeActionButton())
+
+        runWithIdleRes(sessionLoadedIdlingResource) {
+            onView(Matchers.allOf(withId(R.id.display_url), isDisplayed())).check(matches(withText(url)))
+        }
+    }
+
+    fun tapBackToBrowserInPrivateMenu() {
+        onView(withId(R.id.btn_mode)).perform(click())
+    }
+
+    fun checkUrlInPrivateMode(url: String) {
+        uiDevice.findObject(UiSelector().resourceId("display_url").text(url))
+    }
+
+    fun showToastMessageInPrivateMode(activity: PrivateModeActivity, msg: Int) {
+        AndroidTestUtils.toastContainsText(activity, msg)
+    }
+}


### PR DESCRIPTION
New test case:
1. [TC0112] Tap open action notification when private browsing 
2. [TC0115] Tap open action notification when normal browsing
3. [TC0114]  Tap erase private browsing notification when private browsing 
4. [TC0117] Tap erase private browsing notification when normal browsing
5. [TC0118] Tap open action notification after switch to home
6. [TC0120] Tap erase private browsing notification after switch to home
7. [TC0122] show  private browsing erased toast when back to private home page

File Changes:
1.  Add PrivateRobot.kt to support private activity usage
2.  Add NotificationRobot.kt to support notification actions
3.  Add PrivateModeNotification.kt for these 7 test cases