### PR TITLE
fix#3505 Using same style for "No shots" emptyview

### DIFF
--- a/app/src/main/res/layout/fragment_screenshot_grid.xml
+++ b/app/src/main/res/layout/fragment_screenshot_grid.xml
@@ -31,13 +31,8 @@
                 android:src="@drawable/screenshots_empty" />
 
             <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:gravity="center"
                 android:text="@string/screenshot_grid_empty_text_title"
-                android:textColor="@color/colorDownloadSubText"
-                android:textSize="14sp" />
+                style="@style/PanelEmptyHolderText" />
 
             <TextView
                 android:id="@+id/screenshot_grid_empty_text"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -240,7 +240,6 @@
         <item name="android:layout_marginTop">10dp</item>
         <item name="android:textColor">@color/colorDownloadSubText</item>
         <item name="android:textSize">14sp</item>
-        <item name="android:textStyle">italic</item>
     </style>
 
 


### PR DESCRIPTION
Closes #3505 

#### Changes made:
* Used ```"@style/PanelEmptyHolderText"``` for ```No screenshots``` textview.
* Removed redundant code.
* Removed ```italic``` attribute from ```"@style/PanelEmptyHolderText"```. 

#### Screenshots
No shots           |  No bookmarks
:-------------------------:|:-------------------------:
![liteA1](https://user-images.githubusercontent.com/36811908/56502932-8cb33800-652d-11e9-913b-c4a02e2cbff9.png)  | ![image](https://user-images.githubusercontent.com/36811908/56565624-48c24080-65ca-11e9-8eba-a6be8c250b02.png)
