### PR TITLE
add news lifefeed screengrab test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/focus/helper/BeforeTestTask.java
+++ b/app/src/androidTest/java/org/mozilla/focus/helper/BeforeTestTask.java
@@ -17,6 +17,7 @@ import org.mozilla.focus.utils.Settings;
 import org.mozilla.rocket.content.LifeFeedOnboarding;
 
 public class BeforeTestTask {
+    private final boolean enableLifeFeedNews;
     private boolean enableRateAppPromotion;
     private boolean skipFirstRun;
     private boolean clearBrowsingHistory;
@@ -29,6 +30,7 @@ public class BeforeTestTask {
         this.clearBrowsingHistory = builder.clearBrowsingHistory;
         this.enableSreenshotOnBoarding = builder.enableSreenshotOnBoarding;
         this.enableDownloadIndicatorIntro = builder.enableDownloadIndicatorIntro;
+        this.enableLifeFeedNews = builder.enableLifeFeedNews;
     }
 
     public void execute() {
@@ -57,6 +59,11 @@ public class BeforeTestTask {
             if (!this.enableDownloadIndicatorIntro) {
                 settings.getEventHistory().add(Settings.Event.ShowDownloadIndicatorIntro);
             }
+
+            if (this.enableLifeFeedNews) {
+                settings.setLifeFeedSettings("1");
+            }
+
         }
         if (this.clearBrowsingHistory) {
             //TODO: should consider using IdlingResource for DB operation or in-memory DB
@@ -78,6 +85,7 @@ public class BeforeTestTask {
         private boolean enableRateAppPromotion;
         private boolean skipFirstRun;
         private boolean clearBrowsingHistory;
+        private boolean enableLifeFeedNews;
 
         public Builder() {
             this.enableRateAppPromotion = false;
@@ -85,6 +93,8 @@ public class BeforeTestTask {
             this.clearBrowsingHistory = false;
             this.enableSreenshotOnBoarding = false;
             this.enableDownloadIndicatorIntro = false;
+            this.enableLifeFeedNews = false;
+
         }
 
         public Builder setRateAppPromotionEnabled(boolean enable) {
@@ -104,6 +114,11 @@ public class BeforeTestTask {
 
         public Builder enableSreenshotOnBoarding(boolean enableSreenshotOnBoarding) {
             this.enableSreenshotOnBoarding = enableSreenshotOnBoarding;
+            return this;
+        }
+
+        public Builder enableLifeFeedNews(boolean enableLifeFeedNews) {
+            this.enableLifeFeedNews = enableLifeFeedNews;
             return this;
         }
 

--- a/app/src/androidTest/java/org/mozilla/focus/screengrab/NewsFeedScreenshot.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screengrab/NewsFeedScreenshot.java
@@ -1,0 +1,66 @@
+/* -*- Mode: Java; c-basic-offset: 4; tab-width: 20; indent-tabs-mode: nil; -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.screengrab;
+
+import android.content.Intent;
+import android.support.test.espresso.Espresso;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.focus.R;
+import org.mozilla.focus.activity.MainActivity;
+import org.mozilla.focus.annotation.ScreengrabOnly;
+import org.mozilla.focus.helper.BeforeTestTask;
+import org.mozilla.focus.utils.AndroidTestUtils;
+
+import tools.fastlane.screengrab.FalconScreenshotStrategy;
+import tools.fastlane.screengrab.Screengrab;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.core.AllOf.allOf;
+
+@ScreengrabOnly
+@RunWith(AndroidJUnit4.class)
+public class NewsFeedScreenshot extends BaseScreenshot {
+
+    @Rule
+    public final ActivityTestRule<MainActivity> activityTestRule = new ActivityTestRule<>(MainActivity.class, true, false);
+
+    @Before
+    public void setUp() {
+        new BeforeTestTask.Builder()
+                .enableLifeFeedNews(true)
+                .build()
+                .execute();
+        activityTestRule.launchActivity(new Intent());
+        Screengrab.setDefaultScreenshotStrategy(new FalconScreenshotStrategy(activityTestRule.getActivity()));
+    }
+
+    @Test
+    public void screenshotNewsFeed() {
+
+        // Scroll up to see news feed
+        // Note: it needs to tap arrow and menu twice to bring up news feed
+        AndroidTestUtils.tapHomeMenuButton();
+        Espresso.pressBack();
+        onView(allOf(withId(R.id.arrow_container), isDisplayed())).perform(click());
+        AndroidTestUtils.tapHomeMenuButton();
+        Espresso.pressBack();
+        onView(allOf(withId(R.id.arrow_container), isDisplayed())).perform(click());
+        Screengrab.screenshot(ScreenshotNamingUtils.NEWS_LIST);
+
+        // Tap news setting
+        onView(allOf(withId(R.id.news_setting), isDisplayed())).perform(click());
+        Screengrab.screenshot(ScreenshotNamingUtils.NEWS_SETTINGS);
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/screengrab/ScreenshotNamingUtils.java
+++ b/app/src/androidTest/java/org/mozilla/focus/screengrab/ScreenshotNamingUtils.java
@@ -93,4 +93,10 @@ public class ScreenshotNamingUtils {
     private static final String PRIVATE_BROWSING_BASE = "09_private_";
     static final String PRIVATE_ERASING_TOAST = PRIVATE_BROWSING_BASE + "1";
     static final String PRIVATE_ERASING_NOTIFICATION = PRIVATE_BROWSING_BASE + "2";
+
+    private static final String NEWS_FEED_BASE = "10_news_";
+    static final String NEWS_LIST = NEWS_FEED_BASE + "1";
+    static final String NEWS_SETTINGS = NEWS_FEED_BASE + "2";
 }
+
+

--- a/app/src/main/java/org/mozilla/focus/utils/Settings.java
+++ b/app/src/main/java/org/mozilla/focus/utils/Settings.java
@@ -163,6 +163,12 @@ public class Settings {
         return preferences.getString(getPreferenceKey(R.string.pref_key_developer_option_life_feed), "0");
     }
 
+    public void setLifeFeedSettings(String option) {
+        preferences.edit()
+                .putString(getPreferenceKey(R.string.pref_key_developer_option_life_feed), option)
+                .apply();
+    }
+
     @Nullable
     public String getDefaultSearchEngineName() {
         return preferences.getString(getPreferenceKey(R.string.pref_key_search_engine), null);

--- a/fastlane/Screengrabfile
+++ b/fastlane/Screengrabfile
@@ -1,5 +1,5 @@
 
-#locales ['en','hi','in','jv','su','th','tl','zh-TW','vi','ta','kn','ml']
+#locales ['en','hi-IN','in','jv','su','th','tl','zh-TW','vi','ta','kn','ml']
 locales ['vi','zh-TW']
 clear_previous_screenshots true
 exit_on_test_failure false


### PR DESCRIPTION
1. add news life feed category screengrab test
2. screengrab needs to tap arrow and menu twice to open news life feed which needs dev investigation.