### PR TITLE
Glean Integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.jetbrains.python.envs" version "0.0.26"
+}
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -184,6 +188,9 @@ repositories {
     mavenCentral()
 }
 
+ext.gleanGenerateMarkdownDocs = true
+ext.gleanDocsDirectory = "$rootDir/docs"
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
 dependencies {
     implementation project(':telemetry-annotation')
@@ -252,6 +259,7 @@ dependencies {
     implementation "org.mozilla.components:ui-autocomplete:${Versions.android_components}"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:${Versions.android_components}"
     implementation "org.mozilla.components:concept-fetch:${Versions.android_components}"
+    implementation "org.mozilla.components:service-glean:${Versions.mozilla_android_components}"
 
     implementation "com.adjust.sdk:adjust-android:${Versions.adjust}"
     implementation "com.android.installreferrer:installreferrer:${Versions.android_installreferrer}"

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -425,7 +425,9 @@ object TelemetryWrapper {
             val trackerTokenPrefKey = resources.getString(R.string.pref_key_s_tracker_token)
             val channel = AppConstants.getChannel()
 
-            Glean.initialize(context, telemetryEnabled, Configuration(channel = channel))
+            if (AppConstants.isNightlyBuild() || AppConstants.isDevBuild() || AppConstants.isFirebaseBuild()) {
+                Glean.initialize(context, telemetryEnabled, Configuration(channel = channel))
+            }
 
             val configuration = TelemetryConfiguration(context)
                     .setServerEndpoint("https://incoming.telemetry.mozilla.org")

--- a/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
+++ b/app/src/main/java/org/mozilla/focus/telemetry/TelemetryWrapper.kt
@@ -16,6 +16,8 @@ import android.preference.PreferenceManager
 import android.util.Log
 import android.webkit.PermissionRequest
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
+import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.config.Configuration
 import org.mozilla.focus.BuildConfig
 import org.mozilla.focus.R
 import org.mozilla.focus.provider.ScreenshotContract
@@ -402,7 +404,7 @@ object TelemetryWrapper {
         ThreadUtils.postToBackgroundThread {
             // We want to queue this ping and send asap.
             TelemetryWrapper.settingsEvent(key, enabled.toString(), true)
-
+            Glean.setUploadEnabled(enabled)
             // If there are things already collected, we'll still upload them.
             TelemetryHolder.get()
                     .configuration
@@ -422,6 +424,9 @@ object TelemetryWrapper {
 
             val trackerTokenPrefKey = resources.getString(R.string.pref_key_s_tracker_token)
             val channel = AppConstants.getChannel()
+
+            Glean.initialize(context, telemetryEnabled, Configuration(channel = channel))
+
             val configuration = TelemetryConfiguration(context)
                     .setServerEndpoint("https://incoming.telemetry.mozilla.org")
                     .setAppName(TELEMETRY_APP_NAME_ZERDA)

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,16 @@ buildscript {
         maven {
             url 'https://maven.fabric.io/public'
         }
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:${Versions.android_gradle_plugin}"
         classpath "com.google.android.gms:oss-licenses-plugin:${Versions.gms_oss_licenses_plugin}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.navigation}"
+        classpath "org.mozilla.components:tooling-glean-gradle:${Versions.mozilla_android_components}"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,6 +33,7 @@ object Versions {
     const val lottie = "3.4.0"
     const val leakcanary = "2.0-beta-3"
     const val android_components = "0.52.0"
+    const val mozilla_android_components = "39.0.1"
     const val adjust = "4.20.0"
     const val android_installreferrer = "1.1.2"
     const val annotation = "1.1.0"

--- a/tools/metrics/apk_size.py
+++ b/tools/metrics/apk_size.py
@@ -8,7 +8,7 @@ from os import path, listdir, stat
 from sys import exit
 import argparse
 
-SIZE_LIMIT = 6.0 * 1024 * 1024
+SIZE_LIMIT = 6.0 * 1024 * 1024 + 2861397 # exclude the APK size impact from Glean 59
 parser = argparse.ArgumentParser(description='Determine Path')
 parser.add_argument('product', choices=['focus', 'preview'], default='focus')
 parser.add_argument('engine', choices=['webkit'], default='webkit')


### PR DESCRIPTION
Notes:
1. The APK size impact is 600~700KB (with AAB and enabling ABI split). After confirming with @shsu571, this PR is ready for review.

2. I'll add the extra 2861397 bytes that Glean SDK took when checking the APK size. 

3. Glean will only be enabled in debug, firebase, and nightly builds. 