### PR TITLE
Fixes #5344 - Debug builds trigger Strict Mode Violations

### DIFF
--- a/app/src/main/java/org/mozilla/focus/FocusApplication.kt
+++ b/app/src/main/java/org/mozilla/focus/FocusApplication.kt
@@ -135,7 +135,8 @@ open class FocusApplication : LocaleAwareApplication(), LifecycleObserver {
 
         PreferenceManager.setDefaultValues(this, R.xml.settings, false)
 
-        enableStrictMode()
+        // Disabled - see https://github.com/mozilla-mobile/FirefoxLite/issues/5344
+        // enableStrictMode()
 
         SearchEngineManager.getInstance().init(this)
 


### PR DESCRIPTION
This patch disabled strict mode checks completely. They will not be enabled anymore in Debug builds. I'm not a big fan of commenting code in patches, but I thought for context it would be better to just do that with a link to the issue.