### PR TITLE
Fixes #5346 - Upgrade to Target SDK API Level 29

### DIFF
--- a/app/src/test/java/org/mozilla/focus/locale/LocalesTest.java
+++ b/app/src/test/java/org/mozilla/focus/locale/LocalesTest.java
@@ -5,15 +5,19 @@
 
 package org.mozilla.focus.locale;
 
+import android.os.Build;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class LocalesTest {
     @Test
     public void testLanguage() {

--- a/app/src/test/java/org/mozilla/focus/persistence/TabEntityTest.java
+++ b/app/src/test/java/org/mozilla/focus/persistence/TabEntityTest.java
@@ -5,13 +5,17 @@
 
 package org.mozilla.focus.persistence;
 
+import android.os.Build;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class TabEntityTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/focus/screenshot/ScreenshotManagerTest.kt
+++ b/app/src/test/java/org/mozilla/focus/screenshot/ScreenshotManagerTest.kt
@@ -1,14 +1,17 @@
 package org.mozilla.focus.screenshot
 
 import android.app.Application
+import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.utils.FirebaseHelper
 import org.mozilla.focus.utils.FirebaseNoOpImp
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 class ScreenshotManagerTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/focus/search/SearchEngineParserTest.java
+++ b/app/src/test/java/org/mozilla/focus/search/SearchEngineParserTest.java
@@ -5,11 +5,13 @@
 
 package org.mozilla.focus.search;
 
+import android.os.Build;
 import android.text.TextUtils;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -24,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP) // Value of Build.VERSION_CODES.P is 28
 public class SearchEngineParserTest {
     @ParameterizedRobolectricTestRunner.Parameters(name = "{1}")
     public static Collection<Object[]> searchPlugins() {

--- a/app/src/test/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenterTest.kt
+++ b/app/src/test/java/org/mozilla/focus/tabs/tabtray/TabTrayPresenterTest.kt
@@ -6,6 +6,7 @@
 package org.mozilla.focus.tabs.tabtray
 
 import android.graphics.Bitmap
+import android.os.Build
 import android.os.Bundle
 import android.os.Message
 import android.view.View
@@ -32,8 +33,10 @@ import org.mozilla.rocket.tabs.TabViewProvider
 import org.mozilla.rocket.tabs.utils.TabUtil
 import org.mozilla.rocket.tabs.web.DownloadCallback
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 class TabTrayPresenterTest {
 
     private lateinit var tabTrayPresenter: TabTrayPresenter

--- a/app/src/test/java/org/mozilla/focus/utils/ColorUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/ColorUtilsTest.java
@@ -6,14 +6,17 @@
 package org.mozilla.focus.utils;
 
 import android.graphics.Color;
+import android.os.Build;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.*;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class ColorUtilsTest {
     @Test
     public void testGetReadableTextColor() {

--- a/app/src/test/java/org/mozilla/focus/utils/MimeUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/MimeUtilsTest.java
@@ -5,14 +5,18 @@
 
 package org.mozilla.focus.utils;
 
+import android.os.Build;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class MimeUtilsTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/focus/utils/SupportUtilsTest.java
+++ b/app/src/test/java/org/mozilla/focus/utils/SupportUtilsTest.java
@@ -6,18 +6,21 @@
 package org.mozilla.focus.utils;
 
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Locale;
 
 import static org.junit.Assert.*;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class SupportUtilsTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/focus/web/DownloadTest.java
+++ b/app/src/test/java/org/mozilla/focus/web/DownloadTest.java
@@ -5,16 +5,19 @@
 
 package org.mozilla.focus.web;
 
+import android.os.Build;
 import android.os.Parcel;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.rocket.tabs.web.Download;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class DownloadTest {
     @Test
     public void testGetters() {

--- a/app/src/testWebkit/java/org/mozilla/focus/web/WebViewProviderTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/web/WebViewProviderTest.java
@@ -5,13 +5,17 @@
 
 package org.mozilla.focus.web;
 
+import android.os.Build;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.*;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP) // Value of Build.VERSION_CODES.P is 28
 public class WebViewProviderTest {
 
     @Test

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClientTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/TrackingProtectionWebViewClientTest.java
@@ -6,6 +6,7 @@
 package org.mozilla.focus.webkit;
 
 import android.net.Uri;
+import android.os.Build;
 import android.os.StrictMode;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
@@ -32,7 +33,7 @@ import static org.mockito.Mockito.when;
 // http://robolectric.org/getting-started/#note-for-linux-and-mac-users
 
 @RunWith(RobolectricTestRunner.class)
-@Config(packageName = "org.mozilla.focus")
+@Config(packageName = "org.mozilla.focus", maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP_MR1)
 public class TrackingProtectionWebViewClientTest {
 
     private TrackingProtectionWebViewClient trackingProtectionWebViewClient;

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/DisconnectTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/DisconnectTest.java
@@ -6,6 +6,7 @@ package org.mozilla.focus.webkit.matcher;
 
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.Build;
 import android.os.StrictMode;
 import android.preference.PreferenceManager;
 
@@ -32,7 +33,7 @@ import static junit.framework.Assert.assertTrue;
  * This test also verifies that the entity lists (whitelists for specific domains) actually work
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(packageName = "org.mozilla.focus")
+@Config(packageName = "org.mozilla.focus", maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class DisconnectTest {
 
     @After

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/EntityListTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/EntityListTest.java
@@ -6,11 +6,13 @@
 package org.mozilla.focus.webkit.matcher;
 
 import android.net.Uri;
+import android.os.Build;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.focus.webkit.matcher.util.FocusString;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.*;
 
@@ -18,6 +20,7 @@ import static org.junit.Assert.*;
  * Integration test to make sure all our whitelisting methods work as expected.
  */
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class EntityListTest {
 
 

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/TrieTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/TrieTest.java
@@ -5,15 +5,19 @@
 
 package org.mozilla.focus.webkit.matcher;
 
+import android.os.Build;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.focus.webkit.matcher.Trie.WhiteListTrie;
 import org.mozilla.focus.webkit.matcher.util.FocusString;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.*;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class TrieTest {
 
     @Test

--- a/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/UrlMatcherTest.java
+++ b/app/src/testWebkit/java/org/mozilla/focus/webkit/matcher/UrlMatcherTest.java
@@ -6,6 +6,7 @@ package org.mozilla.focus.webkit.matcher;
 
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.Build;
 import android.preference.PreferenceManager;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -16,6 +17,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.focus.webkit.matcher.util.FocusString;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,6 +25,7 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class UrlMatcherTest {
 
     @Test

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,6 +1,6 @@
 object Versions {
     const val min_sdk = 21
-    const val target_sdk = 28
+    const val target_sdk = 29
     const val compile_sdk = 28
     const val build_tools = "28.0.3"
     const val version_code = 1

--- a/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/utils/TabUtilTest.java
+++ b/components/feature/tabs/src/test/java/org/mozilla/rocket/tabs/utils/TabUtilTest.java
@@ -5,6 +5,8 @@
 
 package org.mozilla.rocket.tabs.utils;
 
+import android.os.Build;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -12,7 +14,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@Config(manifest = Config.NONE)
+@Config(manifest = Config.NONE, maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 @RunWith(RobolectricTestRunner.class)
 public class TabUtilTest {
 

--- a/components/utils/urlutils/src/test/java/org/mozilla/urlutils/UrlUtilsTest.java
+++ b/components/utils/urlutils/src/test/java/org/mozilla/urlutils/UrlUtilsTest.java
@@ -6,10 +6,12 @@
 package org.mozilla.urlutils;
 
 import android.annotation.SuppressLint;
+import android.os.Build;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -17,6 +19,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
+@Config(maxSdk = Build.VERSION_CODES.P, minSdk = Build.VERSION_CODES.LOLLIPOP)
 public class UrlUtilsTest {
     @Test
     public void urlsMatchExceptForTrailingSlash() throws Exception {


### PR DESCRIPTION
This patch changes `target_sdk` to `29` and also pulls in https://github.com/mozilla-mobile/FirefoxLite/commit/a18eff2e597fb15e1b58f11152ddea9391d8b734 as a workaround to make RoboElectric tests work again.