### PR TITLE
Request Legacy External Storage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -437,7 +437,7 @@ tasks.whenTaskAdded { task ->
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
-        kotlinOptions.allWarningsAsErrors = true
+        kotlinOptions.allWarningsAsErrors = false
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
 
     <!-- replace="android:supportsRtl for AwesomeBar   -->
     <application
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/org/mozilla/rocket/debugging/DebugActivity.kt
+++ b/app/src/main/java/org/mozilla/rocket/debugging/DebugActivity.kt
@@ -113,7 +113,8 @@ class DebugActivity : AppCompatActivity() {
 
     private fun copyToClipboard(label: String, text: String) {
         ContextCompat.getSystemService(applicationContext, ClipboardManager::class.java)?.run {
-            primaryClip = ClipData.newPlainText(label, text)
+            val clip = ClipData.newPlainText(label, text)
+            this.setPrimaryClip(clip)
         }
     }
 

--- a/app/src/main/java/org/mozilla/rocket/msrp/ui/MissionCouponFragment.kt
+++ b/app/src/main/java/org/mozilla/rocket/msrp/ui/MissionCouponFragment.kt
@@ -128,7 +128,8 @@ class MissionCouponFragment : Fragment() {
 
     private fun copyToClipboard(label: String, text: String) {
         getSystemService(appContext(), ClipboardManager::class.java)?.run {
-            primaryClip = ClipData.newPlainText(label, text)
+            val clip = ClipData.newPlainText(label, text)
+            this.setPrimaryClip(clip)
         }
     }
 

--- a/app/src/main/java/org/mozilla/rocket/shopping/search/data/ShoppingSearchMode.kt
+++ b/app/src/main/java/org/mozilla/rocket/shopping/search/data/ShoppingSearchMode.kt
@@ -12,7 +12,7 @@ class ShoppingSearchMode private constructor(context: Context) {
     fun hasShoppingSearchActivity(): Boolean {
         val manager = appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         for (task in manager.getRunningTasks(Integer.MAX_VALUE)) {
-            if (ShoppingSearchActivity::class.java.name == task.topActivity.className) {
+            if (ShoppingSearchActivity::class.java.name == task.topActivity?.className) {
                 return true
             }
         }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,8 +1,8 @@
 object Versions {
     const val min_sdk = 21
     const val target_sdk = 29
-    const val compile_sdk = 28
-    const val build_tools = "28.0.3"
+    const val compile_sdk = 29
+    const val build_tools = "29.0.2"
     const val version_code = 1
     const val version_name = "2.6.0"
     const val android_gradle_plugin = "3.6.1"


### PR DESCRIPTION
This patch adds `android:requestLegacyExternalStorage="true"` to the manifest to temporarily opt-out of scoped storage. This is something that needs to be properly fixed before the application can move to API level 30 (Android 11).

This is a fix for #5348 (After the API 29 upgrade, screenshots do not work anymore on Android 10 or newer) and requires #5349 to land first since this app settings requires build tools 29.

Thank you @grigoryk for debugging this and finding the root cause.

> Hm this patch has a bit of a weird commit history since I based it on another PR branch.