### PR TITLE
Request Legacy External Storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
 
     <!-- replace="android:supportsRtl for AwesomeBar   -->
     <application
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
> Note that this must land after #5249 - which is why CI may be red.

This patch adds `android:requestLegacyExternalStorage="true"` to the manifest to temporarily opt-out of scoped storage. This is something that needs to be properly fixed before the application can move to API level 30 (Android 11).

This is a fix for #5348 (After the API 29 upgrade, screenshots do not work anymore on Android 10 or newer) and requires #5349 to land first since this app settings requires build tools 29.

Thank you @grigoryk for debugging this and finding the root cause.
